### PR TITLE
Fix README encoding for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup()
+    setup(long_description=open('README.md', encoding='utf-8').read())


### PR DESCRIPTION
## Summary
- handle README encoding when calling setup

## Testing
- `pytest -q`
- `python -m pip install -e .` *(fails: Could not find setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68454ebd8d848320a1d8a19bb083e19d