### PR TITLE
Add CLI interface and entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ from yolov8face import get_bbox
 bboxes = get_bbox("path/to/image.jpg")
 ```
 
+## Command Line Interface
+
+After installing the package you can run face detection directly from the
+command line:
+
+```bash
+yolov8face path/to/image.jpg
+```
+
+The command prints the detected bounding boxes to the terminal.
+
 ## Example
 
 ![Detected faces](https://raw.githubusercontent.com/harshthaker/yolov8face/main/detected_faces.png)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,19 @@ setup(
     install_requires=[
         'ultralytics'
     ],
-    description='Yolov8face is a Python wrapper of Ultrlytics that simplifies the process of detecting faces in images using the yolov8n-face model. It takes care of model downloading, loading and postprocessing, allowing you to detect faces in images with just a few lines of code.',
-    include_package_data=True, # Include additional files like README, LICENSE, etc.
+    description=(
+        'Yolov8face is a Python wrapper of Ultrlytics that simplifies the '
+        'process of detecting faces in images using the yolov8n-face model. '
+        'It takes care of model downloading, loading and postprocessing, '
+        'allowing you to detect faces in images with just a few lines of '
+        'code.'
+    ),
+    include_package_data=True,  # Include additional files like README, LICENSE, etc.
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
+    entry_points={
+        'console_scripts': [
+            'yolov8face=yolov8face.cli:main',
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,34 @@
 from setuptools import setup, find_packages
-import os
 
-setup(
-    name='yolov8face',
-    version='0.1.1',
+
+def _read_description() -> str:
+    """Return the README contents for the long description."""
+    with open("README.md", encoding="utf-8") as fh:
+        return fh.read()
+
+
+setup_params = dict(
+    name="yolov8face",
+    version="0.1.1",
     packages=find_packages(),
-    install_requires=[
-        'ultralytics'
-    ],
+    install_requires=["ultralytics"],
     description=(
-        'Yolov8face is a Python wrapper of Ultrlytics that simplifies the '
-        'process of detecting faces in images using the yolov8n-face model. '
-        'It takes care of model downloading, loading and postprocessing, '
-        'allowing you to detect faces in images with just a few lines of '
-        'code.'
+        "Yolov8face is a Python wrapper of Ultrlytics that simplifies the "
+        "process of detecting faces in images using the yolov8n-face model. "
+        "It takes care of model downloading, loading and postprocessing, "
+        "allowing you to detect faces in images with just a few lines of "
+        "code."
     ),
     include_package_data=True,  # Include additional files like README, LICENSE, etc.
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
+    long_description=_read_description(),
+    long_description_content_type="text/markdown",
     entry_points={
-        'console_scripts': [
-            'yolov8face=yolov8face.cli:main',
+        "console_scripts": [
+            "yolov8face=yolov8face.cli:main",
         ]
     },
 )
+
+
+if __name__ == "__main__":
+    setup(**setup_params)

--- a/yolov8face/cli.py
+++ b/yolov8face/cli.py
@@ -1,0 +1,18 @@
+import argparse
+from .yolo_model import get_bbox
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect faces in an image using YOLOv8")
+    parser.add_argument("image", help="Path to the input image")
+    args = parser.parse_args()
+
+    bboxes = get_bbox(args.image)
+    if bboxes is None:
+        print("Face detection failed.")
+    else:
+        print(bboxes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose a simple command line interface
- allow `yolov8face` to run from shell via console entry point
- document the new CLI usage in the README

## Testing
- `python -m py_compile yolov8face/cli.py yolov8face/yolo_model.py yolov8face/__init__.py setup.py`
- `python -m yolov8face.cli -h` *(fails: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_e_6845408aea748320be8eafa376df54ee